### PR TITLE
Added Disneyland and DCA to Disneyworld

### DIFF
--- a/lib/echelon/parks/disney_world.rb
+++ b/lib/echelon/parks/disney_world.rb
@@ -38,6 +38,14 @@ module Echelon
       @epcot ||= DisneyWorld::Epcot.new(access_token)
     end
 
+    def disneyland
+      @disneyland ||= DisneyWorld::Disneyland.new(access_token)
+    end
+
+    def california_adventure
+      @california_adventure ||= DisneyWorld::CaliforniaAdventure.new(access_token)
+    end
+
     class Park < Echelon::Park
       attr_reader :json_data
 
@@ -107,6 +115,18 @@ module Echelon
     class AnimalKingdom < Park
       def initialize(access_token)
         super(access_token, 80_007_823)
+      end
+    end
+
+    class Disneyland < Park
+      def initialize(access_token)
+        super(access_token, 330339)
+      end
+    end
+
+    class CaliforniaAdventure < Park
+      def initialize(access_token)
+        super(access_token, 336894)
       end
     end
   end


### PR DESCRIPTION
I've gone ahead and fixed Disneyland and Disney California Adventure. Currently, they're listed under DisneyWorld, although that may not be ideal. The APIs that the parks call are identical. How would you like to proceed?
